### PR TITLE
New resolution options and multi-monitor support

### DIFF
--- a/Src/BeebEm.rc
+++ b/Src/BeebEm.rc
@@ -546,6 +546,8 @@ BEGIN
             MENUITEM "1440x900",                    ID_VIEW_DD_1440X900
             MENUITEM "1600x1200",                   ID_VIEW_DD_1600X1200
             MENUITEM "1920x1080 (1080p)",           ID_VIEW_DD_1920X1080
+            MENUITEM "2560x1440",                   ID_VIEW_DD_2560X1440
+            MENUITEM "3840x2160 (4K)",              ID_VIEW_DD_3840X2160
         END
         MENUITEM SEPARATOR
         POPUP "Monitor type"

--- a/Src/beebemrc.h
+++ b/Src/beebemrc.h
@@ -425,6 +425,8 @@ Boston, MA  02110-1301, USA.
 #define ID_VIEW_DD_1280X720             40288
 #define ID_VIEW_DD_1920X1080            40289
 #define IDM_ARMCOPRO                    40290
+#define ID_VIEW_DD_2560X1440            40291
+#define ID_VIEW_DD_3840X2160            40292
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -433,7 +435,7 @@ Boston, MA  02110-1301, USA.
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        117
-#define _APS_NEXT_COMMAND_VALUE         40291
+#define _APS_NEXT_COMMAND_VALUE         40293
 #define _APS_NEXT_CONTROL_VALUE         1087
 #define _APS_NEXT_SYMED_VALUE           101
 #endif

--- a/Src/beebwin.cpp
+++ b/Src/beebwin.cpp
@@ -203,6 +203,8 @@ BeebWin::BeebWin()
 	m_startFullScreen = false;
 	m_XDXSize = 640;
 	m_YDXSize = 480;
+	m_XDXPos = 0;
+	m_YDXPos = 0;
 	m_XScrSize = GetSystemMetrics(SM_CXSCREEN);
 	m_YScrSize = GetSystemMetrics(SM_CYSCREEN);
 	m_XWinBorder = GetSystemMetrics(SM_CXSIZEFRAME) * 2;
@@ -838,6 +840,8 @@ void BeebWin::InitMenu(void)
 	CheckMenuItem(ID_VIEW_DD_1440X900, false);
 	CheckMenuItem(ID_VIEW_DD_1600X1200, false);
 	CheckMenuItem(ID_VIEW_DD_1920X1080, false);
+	CheckMenuItem(ID_VIEW_DD_2560X1440, false);
+	CheckMenuItem(ID_VIEW_DD_3840X2160, false);
 	CheckMenuItem(m_DDFullScreenMode, true);
 
 	// View -> Motion blur
@@ -1868,6 +1872,14 @@ void BeebWin::TranslateDDSize(void)
 		m_XDXSize = 1920;
 		m_YDXSize = 1080;
 		break;
+	case ID_VIEW_DD_2560X1440:
+		m_XDXSize = 2560;
+		m_YDXSize = 1440;
+		break;
+	case ID_VIEW_DD_3840X2160:
+		m_XDXSize = 3840;
+		m_YDXSize = 2160;
+		break;
 	case ID_VIEW_DD_SCREENRES:
 		// Pixel size of default monitor
 		m_XDXSize = GetSystemMetrics(SM_CXSCREEN);
@@ -2192,6 +2204,21 @@ void BeebWin::SetWindowAttributes(bool wasFullScreen)
 
 	if (m_isFullScreen)
 	{
+		// Get the monitor that the BeebEm window is on to account for multiple monitors
+		if (m_DDFullScreenMode == ID_VIEW_DD_SCREENRES)
+		{
+			HMONITOR monitor = MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST);
+			MONITORINFO info;
+			info.cbSize = sizeof(MONITORINFO);
+			GetMonitorInfo(monitor, &info);
+
+			// Get current resolution of the monitor
+			m_XDXSize = info.rcMonitor.right - info.rcMonitor.left;
+			m_YDXSize = info.rcMonitor.bottom - info.rcMonitor.top;
+			m_XDXPos = info.rcMonitor.left;
+			m_YDXPos = info.rcMonitor.top;
+		}
+
 		if (!wasFullScreen)
 		{
 			GetWindowRect(m_hWnd, &wndrect);
@@ -2203,7 +2230,7 @@ void BeebWin::SetWindowAttributes(bool wasFullScreen)
 		{
 			m_XWinSize = m_XDXSize;
 			m_YWinSize = m_YDXSize;
-			CalcAspectRatioAdjustment(m_XScrSize, m_YScrSize);
+			CalcAspectRatioAdjustment(m_XDXSize, m_YDXSize);
 
 			style = GetWindowLong(m_hWnd, GWL_STYLE);
 			style &= ~(WIN_STYLE);
@@ -2838,6 +2865,8 @@ void BeebWin::HandleCommand(int MenuId)
 	case ID_VIEW_DD_1440X900:
 	case ID_VIEW_DD_1600X1200:
 	case ID_VIEW_DD_1920X1080:
+	case ID_VIEW_DD_2560X1440:
+	case ID_VIEW_DD_3840X2160:
 		// Ignore ID_VIEW_DD_SCREENRES if already in full screen mode
 		if ((MenuId != ID_VIEW_DD_SCREENRES) || !m_isFullScreen)
 		{

--- a/Src/beebwin.h
+++ b/Src/beebwin.h
@@ -270,6 +270,8 @@ public:
 	int		m_YWinPos;
 	int		m_XDXSize;
 	int		m_YDXSize;
+	int		m_XDXPos;
+	int		m_YDXPos;
 	int		m_XScrSize;
 	int		m_YScrSize;
 	int		m_XWinBorder;

--- a/Src/beebwindx.cpp
+++ b/Src/beebwindx.cpp
@@ -321,9 +321,26 @@ HRESULT BeebWin::InitDX9(void)
 		d3dpp.hDeviceWindow = m_hWnd;
 		d3dpp.EnableAutoDepthStencil = FALSE;
 
+		/* Find the monitor index based on the window BeebEm is currently on
+		   as needed to pass to CreateDevice(). */
+		HMONITOR monitor = MonitorFromWindow(m_hWnd, MONITOR_DEFAULTTONEAREST);
+		MONITORINFO info;
+		info.cbSize = sizeof(MONITORINFO);
+		GetMonitorInfo(monitor, &info);
+
+		int currentMonitorIndex;
+		unsigned int adapterCount = m_pD3D->GetAdapterCount();
+
+		for (unsigned int i = 0; i < adapterCount; i++)
+		{
+			HMONITOR monToCheck = m_pD3D->GetAdapterMonitor(i);
+			if (monitor == monToCheck)
+				currentMonitorIndex = i;
+		}
+
 		// Create the D3DDevice
 		hr = m_pD3D->CreateDevice(
-			D3DADAPTER_DEFAULT, D3DDEVTYPE_HAL, m_hWnd,
+			currentMonitorIndex, D3DDEVTYPE_HAL, m_hWnd,
 			D3DCREATE_SOFTWARE_VERTEXPROCESSING,
 			&d3dpp, &m_pd3dDevice );
 	}

--- a/Src/beebwinprefs.cpp
+++ b/Src/beebwinprefs.cpp
@@ -130,7 +130,7 @@ void BeebWin::LoadPreferences()
 	if (m_Preferences.GetDWORDValue("DDFullScreenMode", dword))
 		m_DDFullScreenMode = dword;
 	else
-		m_DDFullScreenMode = ID_VIEW_DD_640X480;
+		m_DDFullScreenMode = ID_VIEW_DD_SCREENRES;
 	TranslateDDSize();
 
 	if (m_Preferences.GetDWORDValue(CFG_VIEW_WIN_SIZE, dword))


### PR DESCRIPTION
* Added new DX video modes for full-screen (1440p and 4K).
* Fixed issue where BeebEm would always use the primary monitor when going
  fullscreen.
  - Now uses monitor on which the BeebEm window is positioned.  As with all
    DX9 applications, this works best when "Current Screen Resolultion" is
    selected.
* Changed the default fullscreen resolution to "Current Screen Resolution".